### PR TITLE
Added functionality for ranges of movies in cli mode

### DIFF
--- a/subgrab/cli.py
+++ b/subgrab/cli.py
@@ -117,16 +117,19 @@ def main():
         # Searches for the specified movie.
         args.media_name = " ".join(args.media_name)
         logger.info("Searching For: {}".format(args.media_name))
-        sub_link = subscene.sel_title(name=args.media_name.replace(" ", "."))
-        logger.info(
-            "Subtitle Link for {} : {}".format(args.media_name, sub_link)
-        )
-        if sub_link:
-            for i in subscene.sel_sub(
-                page=sub_link, sub_count=args.count, name=args.media_name
-            ):
-                logger.debug("Downloading Subtitle: {}\n".format(i))
-                subscene.dl_sub(i)
+        sub_links = subscene.sel_title(name=args.media_name.replace(" ", "."))
+        if sub_links:
+            for sub_link in sub_links:
+                logger.info(
+                    "Subtitle Link for {} : {}".format(args.media_name, sub_link)
+                )
+                if sub_link:
+                    for i in subscene.sel_sub(
+                        page=sub_link, sub_count=args.count, name=args.media_name
+                    ):
+                        logger.debug("Downloading Subtitle: {}\n".format(i))
+                        names = subscene.dl_sub(i)
+                    time.sleep(1)
 
     else:
         print("Incorrect Arguments Specified.")

--- a/subgrab/providers/subscene.py
+++ b/subgrab/providers/subscene.py
@@ -120,16 +120,29 @@ def cli_mode(titles_name, category):
         titles_and_links[title_text] = x.a.get("href")
         print("({}): {}".format(i, title_text))
         media_titles.append(title_text)
-
     try:
-        qs = int(input("\nPlease Enter Movie Number: "))
+        qs = (input("\nPlease Enter Movie Number(s): "))
+        qs = qs.split(",")
+        numbers = []
+        subtitle_urls = []
+        for innerq in qs:
+            if len(innerq.split("-"))==2:
+                first_number = int(innerq.split("-")[0].strip())
+                second_number = int(innerq.split("-")[1].strip())
+                numbers = numbers + list(range(first_number,second_number+1))
+            else:
+                numbers.append(int(innerq.strip()))
+        numbers = sorted(set(numbers))
+        for number in numbers:
+            subtitle_urls.append(
+                "https://subscene.com"
+                + titles_and_links[media_titles[number]]
+                + "/"
+                + DEFAULT_LANG
+            )
         return (
-            "https://subscene.com"
-            + titles_and_links[media_titles[qs]]
-            + "/"
-            + DEFAULT_LANG
+            subtitle_urls
         )
-
     except Exception as e:
         logger.warning("Movie Skipped - {}".format(e))
         # If pressed Enter, movie is skipped.


### PR DESCRIPTION
Instead of only picking a single movie from the list of results, I changed the functionality so that users can select multiple movies using '-' for a range and ',' for unique numbers. For example: 

`Please Enter Movie Number: 0, 2-7` downloads movies 0, 2, 3, 4, 5, 6 and 7.
